### PR TITLE
Fedora: restore `inst.stage2`

### DIFF
--- a/fedora.pkr.hcl
+++ b/fedora.pkr.hcl
@@ -24,6 +24,7 @@ source "qemu" "fedora" {
     "c<wait10>",
     "set gfxpayload=keep<enter><wait>",
     "linux /images/pxeboot/vmlinuz console=ttyS0 inst.notmux inst.cmdline ",
+    "inst.stage2=hd:/dev/sr0 ",
     "inst.ks=http://{{.HTTPIP}}:{{.HTTPPort}}/fedora.ks<enter><wait>",
     "initrd /images/pxeboot/initrd.img<enter><wait10>",
     "boot<enter>"


### PR DESCRIPTION
Fixes 6586313fb08a9cf2e17d3426a08ca5c7d4576fa9