### PR TITLE
Download more RAM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure(2) do |config|
   config.vm.provider :libvirt do |libvirt; box_dir|
-    libvirt.memory = 4096
+    libvirt.memory = 8192
 
     if File.exist?('/dev/kvm')
       libvirt.driver = 'kvm'

--- a/alpine.pkr.hcl
+++ b/alpine.pkr.hcl
@@ -12,7 +12,7 @@ locals {
 source "qemu" "alpine" {
   vga = "virtio"
   cpus = 2
-  memory = 4096
+  memory = 8192
   headless = var.headless
   qmp_enable = var.headless
   shutdown_command = "/sbin/poweroff"

--- a/archlinux.pkr.hcl
+++ b/archlinux.pkr.hcl
@@ -8,7 +8,7 @@ source "qemu" "archlinux" {
   iso_checksum = "file:https://geo.mirror.pkgbuild.com/iso/${local.archlinux_version}/sha256sums.txt"
   vga = "virtio"
   cpus = 2
-  memory = 4096
+  memory = 8192
   headless = var.headless
   shutdown_command = "/sbin/poweroff"
   qmp_enable = var.headless

--- a/debian.pkr.hcl
+++ b/debian.pkr.hcl
@@ -6,7 +6,7 @@ locals {
 source "qemu" "debian" {
   vga = "virtio"
   cpus = 2
-  memory = 4096
+  memory = 8192
   headless = var.headless
   qmp_enable = var.headless
   shutdown_command = "shutdown -P now"

--- a/fedora.pkr.hcl
+++ b/fedora.pkr.hcl
@@ -12,7 +12,7 @@ locals {
 source "qemu" "fedora" {
   vga = "virtio"
   cpus = 2
-  memory = 4096
+  memory = 8192
   headless = var.headless
   qmp_enable = var.headless
   shutdown_command = "sudo shutdown -P now"

--- a/nixos.pkr.hcl
+++ b/nixos.pkr.hcl
@@ -21,7 +21,7 @@ source "qemu" "nixos" {
   iso_checksum = "sha256:${split(" ", data.http.nixos_iso_checksum.body)[0]}"
   vga = "virtio"
   cpus = 2
-  memory = 4096
+  memory = 8192
   headless = var.headless
   shutdown_command = "sudo shutdown -P now"
   qmp_enable = var.headless

--- a/opensuse.pkr.hcl
+++ b/opensuse.pkr.hcl
@@ -22,7 +22,7 @@ local "opensusetumbleweed_iso_name" {
 source "qemu" "opensuse" {
   vga = "virtio"
   cpus = 2
-  memory = 4096
+  memory = 8192
   headless = var.headless
   qmp_enable = var.headless
   shutdown_command = "sudo /sbin/halt -h -p"

--- a/ubuntu.pkr.hcl
+++ b/ubuntu.pkr.hcl
@@ -8,7 +8,7 @@ locals {
 source "qemu" "ubuntu" {
   vga = "virtio"
   cpus = 2
-  memory = 4096
+  memory = 8192
   headless = var.headless
   qmp_enable = var.headless
   shutdown_command = "sudo shutdown -P now"


### PR DESCRIPTION
GitHub-hosted runners have 16 GB RAM. Use half of that.

RAM size is often used to determine swap size, and Ubuntu installers sometimes fail on low RAM.