### PR TITLE
ci: upload unarchived screenshots and boxes

### DIFF
--- a/.github/workflows/box.yml
+++ b/.github/workflows/box.yml
@@ -73,7 +73,7 @@ jobs:
 
       - run: >-
           /usr/bin/packer build
-          ${{ !inputs.publish && '-except vagrant-registry' || '' }}
+          ${{ case(inputs.publish, '', '-except vagrant-registry') }}
           -only "$BUILD_NAME"
           .
           2>&1 | tee logs/packer.txt

--- a/.github/workflows/box.yml
+++ b/.github/workflows/box.yml
@@ -85,13 +85,15 @@ jobs:
           BUILD_NAME: qemu.${{ inputs.name }}
 
       - run: du -h ./*.box
+      - run: mv ./*.box "${BOX_NAME}"
+        env:
+          BOX_NAME: ${{ inputs.name }}.box
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ${{ inputs.name }}-box
-          path: '*.box'
+          path: ${{ inputs.name }}.box
           retention-days: 1
-          compression-level: 0
+          archive: false
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -137,7 +139,8 @@ jobs:
 
       - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
-          name: ${{ inputs.name }}-box
+          name: ${{ inputs.name }}.box
+          skip-decompress: true
 
       - run: vagrant box add --clean --force --no-tty --name "$BOX_NAME" ./*.box
         env:

--- a/.github/workflows/box.yml
+++ b/.github/workflows/box.yml
@@ -161,15 +161,31 @@ jobs:
 
       - run: sleep 30
 
-      - run: virsh --connect=qemu:///session screenshot "$VIRT_DOMAIN_NAME" --file logs/screenshot.png
+      - id: screenshot
+        run: virsh --connect=qemu:///session screenshot "$VIRT_DOMAIN_NAME" --file "$SCREENSHOT"
         env:
           VIRT_DOMAIN_NAME: ${{ steps.virt_domain_name.outputs.virt_domain_name }}
+          SCREENSHOT: logs/${{ inputs.name }}.png
 
       - run: vagrant destroy --force --graceful
 
-      - run: compare -crop '1280x768+0+32' logs/screenshot.png "$REF_IMAGE" logs/screenshot-diff.png
+      - run: compare -crop '1280x768+0+32' "$SCREENSHOT" "$REF_IMAGE" "$SCREENSHOT_DIFF"
         env:
           REF_IMAGE: test/ref/${{ inputs.name }}.png
+          SCREENSHOT: logs/${{ inputs.name }}.png
+          SCREENSHOT_DIFF: logs/${{ inputs.name }}-diff.png
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          path: logs/${{ inputs.name }}.png
+          archive: false
+        if: ${{ always() && steps.screenshot.outcome == 'success' }}
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          path: logs/${{ inputs.name }}-diff.png
+          archive: false
+        if: ${{ always() && steps.screenshot.outcome == 'success' }}
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/.github/workflows/box.yml
+++ b/.github/workflows/box.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           name: ${{ inputs.name }}-build-logs
           path: logs
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
 
   test:
     name: test ${{ inputs.name }}
@@ -191,4 +191,4 @@ jobs:
         with:
           name: ${{ inputs.name }}-test-logs
           path: logs
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}


### PR DESCRIPTION
They are already compressed.

Now it will be possible to view screenshots directly from GitHub.